### PR TITLE
Add workaround for cc crate failing on macOS

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -14,4 +14,7 @@ build-std = ["std", "panic_abort"]
 MCU="esp32s3"
 # Note: this variable is not used by the pio builder (`cargo build --features pio`)
 ESP_IDF_VERSION = "v5.1.3"
-
+# Workaround for https://github.com/esp-rs/esp-idf-template/issues/174 until
+# https://github.com/esp-rs/esp-idf-hal/pull/387 gets released and the template
+# updated.
+CRATE_CC_NO_DEFAULTS = "1"


### PR DESCRIPTION
This backports https://github.com/esp-rs/esp-idf-template/pull/208 to this project template.