### PR TITLE
Refer to prerequisites directly from esp-idf-template

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,8 @@ This is the Rust Slint Template for ESP32-S3-BOX-3B based on ESP-IDF.
 
 ## Environment setup
 
-Use `espup` to install Espressif Rust ecosystem: 
-
-```shell
-cargo install espup
-espup install
-```
+Follow the prerequisites for
+[esp-idf-template](https://github.com/esp-rs/esp-idf-template?tab=readme-ov-file#prerequisites).
 
 For each new terminal session, you need to set up the environment:
 


### PR DESCRIPTION
Running `espup` does just install the toolchain. There are more tools required and the esp-idf-template gives detailed instructions.