### PR TITLE
Fixes based on Oxidize workshop

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ sudo apt install wget flex bison gperf cmake ninja-build ccache libffi-dev dfu-u
 #### 2. Install ESP toolchain for Rust
 
 ```sh
-cargo install espup # ESP toolchain setup
+cargo install espup --locked # ESP toolchain setup
 cargo install espflash # Flashing tool
 ```
 

--- a/model/src/lib.rs
+++ b/model/src/lib.rs
@@ -1,7 +1,6 @@
 #![no_std]
 
 extern crate alloc;
-use crate::alloc::string::ToString;
 use alloc::{string::String, vec::Vec};
 /// Simple Struct for storing WiFi Network data.
 pub struct WifiNetwork {

--- a/winit/Cargo.toml
+++ b/winit/Cargo.toml
@@ -12,7 +12,6 @@ chrono = "0.4"                                      # To display the current tim
 log = { version = "0.4", default-features = false } # Use log for logging
 
 slint = "1.13"  # Use the slint library for the UI
-rs-wifi = "0.1"
 
 # Include the model package as a dependency
 slint-workshop-model = { path = "../model" }


### PR DESCRIPTION
Remove unused import <- fixes clippy warning

Remove rs-wifi dependency <- unused, allows compilation on MacOS

Add --locked for espup <- fixes installation error